### PR TITLE
Add pessimistic locking to prevent overbooking in GymClass bookings

### DIFF
--- a/src/main/java/com/example/boka/booking/application/BookingService.java
+++ b/src/main/java/com/example/boka/booking/application/BookingService.java
@@ -4,6 +4,7 @@ import com.example.boka.booking.UserBookingResponse;
 import com.example.boka.booking.domain.Booking;
 import com.example.boka.booking.domain.BookingStatus;
 import com.example.boka.booking.domain.BookingRepository;
+import com.example.boka.common.ResourceNotFoundException;
 import com.example.boka.common.UserNotFoundException;
 import com.example.boka.gymclass.GymClassProviderPort;
 import com.example.boka.user.UserProviderPort;
@@ -64,10 +65,20 @@ public class BookingService {
         UserProviderPort.UserDetails user = userProviderPort.findByEmail(userEmail)
                 .orElseThrow(() -> new UserNotFoundException(userEmail));
 
+        // Acquire a pessimistic write lock on the gym class row to prevent concurrent overbooking
+        int capacity = gymClassProviderPort.lockAndGetCapacity(gymClassId)
+                .orElseThrow(() -> new ResourceNotFoundException("GymClass", "id", gymClassId));
+
         // Check if already booked
         List<Booking> existingBookings = bookingRepository.findByUserIdAndGymClassIdAndStatus(user.id(), gymClassId, BookingStatus.CONFIRMED);
         if (!existingBookings.isEmpty()) {
             throw new IllegalStateException("Already booked this class");
+        }
+
+        // Enforce capacity — count is taken after the lock, so it is accurate
+        long confirmedCount = bookingRepository.countByGymClassIdAndStatus(gymClassId, BookingStatus.CONFIRMED);
+        if (confirmedCount >= capacity) {
+            throw new IllegalStateException("Class is full");
         }
 
         Booking booking = new Booking();

--- a/src/main/java/com/example/boka/booking/application/BookingService.java
+++ b/src/main/java/com/example/boka/booking/application/BookingService.java
@@ -10,6 +10,7 @@ import com.example.boka.gymclass.GymClassProviderPort;
 import com.example.boka.user.UserProviderPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,30 +66,32 @@ public class BookingService {
         UserProviderPort.UserDetails user = userProviderPort.findByEmail(userEmail)
                 .orElseThrow(() -> new UserNotFoundException(userEmail));
 
-        // Acquire a pessimistic write lock on the gym class row to prevent concurrent overbooking
-        int capacity = gymClassProviderPort.lockAndGetCapacity(gymClassId)
-                .orElseThrow(() -> new ResourceNotFoundException("GymClass", "id", gymClassId));
-
-        // Check if already booked
-        List<Booking> existingBookings = bookingRepository.findByUserIdAndGymClassIdAndStatus(user.id(), gymClassId, BookingStatus.CONFIRMED);
-        if (!existingBookings.isEmpty()) {
-            throw new IllegalStateException("Already booked this class");
-        }
-
-        // Enforce capacity — count is taken after the lock, so it is accurate
-        long confirmedCount = bookingRepository.countByGymClassIdAndStatus(gymClassId, BookingStatus.CONFIRMED);
-        if (confirmedCount >= capacity) {
-            throw new IllegalStateException("Class is full");
-        }
-
-        Booking booking = new Booking();
-        booking.setUserId(user.id());
-        booking.setGymClassId(gymClassId);
-        booking.setStatus(BookingStatus.CONFIRMED);
-
         try {
+            // Acquire a pessimistic write lock on the gym class row to prevent concurrent overbooking
+            int capacity = gymClassProviderPort.lockAndGetCapacity(gymClassId)
+                    .orElseThrow(() -> new ResourceNotFoundException("GymClass", "id", gymClassId));
+
+            // Check if already booked
+            List<Booking> existingBookings = bookingRepository.findByUserIdAndGymClassIdAndStatus(user.id(), gymClassId, BookingStatus.CONFIRMED);
+            if (!existingBookings.isEmpty()) {
+                throw new IllegalStateException("Already booked this class");
+            }
+
+            // Enforce capacity — count is taken after the lock, so it is accurate
+            long confirmedCount = bookingRepository.countByGymClassIdAndStatus(gymClassId, BookingStatus.CONFIRMED);
+            if (confirmedCount >= capacity) {
+                throw new IllegalStateException("Class is full");
+            }
+
+            Booking booking = new Booking();
+            booking.setUserId(user.id());
+            booking.setGymClassId(gymClassId);
+            booking.setStatus(BookingStatus.CONFIRMED);
+
             Booking saved = bookingRepository.save(booking);
             return new BookingResponse(saved.getId(), gymClassId, user.email(), "CONFIRMED");
+        } catch (PessimisticLockingFailureException e) {
+            throw new IllegalStateException("Class is temporarily unavailable, please try again");
         } catch (DataIntegrityViolationException e) {
             throw new IllegalStateException("Already booked this class");
         }

--- a/src/main/java/com/example/boka/booking/domain/BookingRepository.java
+++ b/src/main/java/com/example/boka/booking/domain/BookingRepository.java
@@ -14,6 +14,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     List<Booking> findByUserId(Long userId);
     List<Booking> findByGymClassId(Long gymClassId);
     List<Booking> findByUserIdAndGymClassIdAndStatus(Long userId, Long gymClassId, BookingStatus status);
+    long countByGymClassIdAndStatus(Long gymClassId, BookingStatus status);
 
     @Query("SELECT b.gymClassId, COUNT(b) FROM Booking b WHERE b.status = :status AND b.gymClassId IN :gymClassIds GROUP BY b.gymClassId")
     List<Object[]> findCountsByGymClassIdsAndStatus(@Param("gymClassIds") Set<Long> gymClassIds, @Param("status") BookingStatus status);

--- a/src/main/java/com/example/boka/gymclass/GymClassProviderPort.java
+++ b/src/main/java/com/example/boka/gymclass/GymClassProviderPort.java
@@ -3,6 +3,7 @@ package com.example.boka.gymclass;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface GymClassProviderPort {
 
@@ -14,4 +15,7 @@ public interface GymClassProviderPort {
     ) {}
 
     Map<Long, GymClassDetails> getGymClassDetails(List<Long> gymClassIds);
+
+    /** Acquires a pessimistic write lock on the gym class row and returns its capacity. */
+    Optional<Integer> lockAndGetCapacity(Long gymClassId);
 }

--- a/src/main/java/com/example/boka/gymclass/domain/GymClassRepository.java
+++ b/src/main/java/com/example/boka/gymclass/domain/GymClassRepository.java
@@ -1,15 +1,24 @@
 package com.example.boka.gymclass.domain;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface GymClassRepository extends JpaRepository<GymClass, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT gc FROM GymClass gc WHERE gc.id = :id")
+    Optional<GymClass> findWithLockById(@Param("id") Long id);
 
     Page<GymClass> findByClassType_IdInAndStatusAndStartTimeAfter(
             List<Long> classTypeIds, ClassStatus status, LocalDateTime time, Pageable pageable

--- a/src/main/java/com/example/boka/gymclass/domain/GymClassRepository.java
+++ b/src/main/java/com/example/boka/gymclass/domain/GymClassRepository.java
@@ -1,11 +1,13 @@
 package com.example.boka.gymclass.domain;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -17,6 +19,7 @@ import java.util.Optional;
 public interface GymClassRepository extends JpaRepository<GymClass, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
     @Query("SELECT gc FROM GymClass gc WHERE gc.id = :id")
     Optional<GymClass> findWithLockById(@Param("id") Long id);
 

--- a/src/main/java/com/example/boka/gymclass/infrastructure/GymClassProviderAdapter.java
+++ b/src/main/java/com/example/boka/gymclass/infrastructure/GymClassProviderAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -15,6 +16,12 @@ import java.util.stream.Collectors;
 public class GymClassProviderAdapter implements GymClassProviderPort {
 
     private final GymClassRepository gymClassRepository;
+
+    @Override
+    public Optional<Integer> lockAndGetCapacity(Long gymClassId) {
+        return gymClassRepository.findWithLockById(gymClassId)
+                .map(GymClass::getCapacity);
+    }
 
     @Override
     public Map<Long, GymClassDetails> getGymClassDetails(List<Long> gymClassIds) {

--- a/src/test/java/com/example/boka/booking/application/BookingServiceTest.java
+++ b/src/test/java/com/example/boka/booking/application/BookingServiceTest.java
@@ -45,8 +45,10 @@ class BookingServiceTest {
         // Arrange
         UserProviderPort.UserDetails userDetails = new UserProviderPort.UserDetails(testUserId, testEmail);
         when(userProviderPort.findByEmail(testEmail)).thenReturn(Optional.of(userDetails));
+        when(gymClassProviderPort.lockAndGetCapacity(testClassId)).thenReturn(Optional.of(10));
         when(bookingRepository.findByUserIdAndGymClassIdAndStatus(testUserId, testClassId, BookingStatus.CONFIRMED))
                 .thenReturn(Collections.emptyList());
+        when(bookingRepository.countByGymClassIdAndStatus(testClassId, BookingStatus.CONFIRMED)).thenReturn(5L);
 
         Booking savedBooking = new Booking();
         savedBooking.setId(500L);
@@ -67,6 +69,7 @@ class BookingServiceTest {
         // Arrange
         UserProviderPort.UserDetails userDetails = new UserProviderPort.UserDetails(testUserId, testEmail);
         when(userProviderPort.findByEmail(testEmail)).thenReturn(Optional.of(userDetails));
+        when(gymClassProviderPort.lockAndGetCapacity(testClassId)).thenReturn(Optional.of(10));
         when(bookingRepository.findByUserIdAndGymClassIdAndStatus(testUserId, testClassId, BookingStatus.CONFIRMED))
                 .thenReturn(List.of(new Booking()));
 


### PR DESCRIPTION
- Introduce `lockAndGetCapacity` method in `GymClassProviderPort` and its implementation.
- Add `findWithLockById` to `GymClassRepository` using a pessimistic write lock.
- Enforce capacity checks with accurate count post-lock in `BookingService`.
- Update `BookingRepository` with `countByGymClassIdAndStatus` for validated capacity checks.
- Handle missing gym classes gracefully with `ResourceNotFoundException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capacity-based booking validation to prevent users from booking gym classes that have reached their maximum participant limits

* **Bug Fixes**
  * Improved concurrent request handling to prevent race conditions that could allow overbooking of full classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->