### PR TITLE
Update Fly.io config and Dockerfile for optimized resource usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,9 @@ FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 COPY --from=backend-builder /app/target/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java",
+  "-Xms128m",
+  "-Xmx384m",
+  "-XX:+UseG1GC",
+  "-XX:MaxRAMPercentage=75",
+  "-jar", "app.jar"]

--- a/fly.toml
+++ b/fly.toml
@@ -11,9 +11,9 @@ primary_region = 'arn'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
- Set `auto_stop_machines` to false and require at least 1 running machine in `fly.toml`.
- Adjust Dockerfile to optimize JVM memory settings with G1GC and RAM limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized JVM memory allocation and garbage collection settings for enhanced application performance.
  * Updated deployment configuration to ensure continuous service availability by maintaining at least one running instance at all times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->